### PR TITLE
Updated metadata provider signature to pass current message

### DIFF
--- a/runner/data.go
+++ b/runner/data.go
@@ -35,7 +35,7 @@ var ErrLastMessage = errors.New("last message")
 type DataProviderFunc func(*CallData) ([]*dynamic.Message, error)
 
 // MetadataProviderFunc is the interface for providing metadadata for calls
-type MetadataProviderFunc func(*CallData) (*metadata.MD, error)
+type MetadataProviderFunc func(*CallData, *dynamic.Message) (*metadata.MD, error)
 
 // StreamMessageProviderFunc is the interface for providing a message for every message send in the course of a streaming call
 type StreamMessageProviderFunc func(*CallData) (*dynamic.Message, error)
@@ -257,7 +257,7 @@ func newMetadataProvider(mtd *desc.MethodDescriptor, mdData []byte, withFuncs, w
 	return &mdProvider{metadata: mdData, preseed: preseed}, nil
 }
 
-func (dp *mdProvider) getMetadataForCall(ctd *CallData) (*metadata.MD, error) {
+func (dp *mdProvider) getMetadataForCall(ctd *CallData, msg *dynamic.Message) (*metadata.MD, error) {
 	if dp.preseed != nil {
 		return &dp.preseed, nil
 	}

--- a/runner/data_test.go
+++ b/runner/data_test.go
@@ -310,7 +310,7 @@ func TestMetadata_getMetadataForCall(t *testing.T) {
 
 		cd := newCallData(mtdUnary, "123", 1, true, true, nil)
 
-		md, err := mdp.getMetadataForCall(cd)
+		md, err := mdp.getMetadataForCall(cd, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, md)
 		assert.Equal(t, []string{"asdf"}, md.Get("token"))
@@ -330,14 +330,14 @@ func TestMetadata_getMetadataForCall(t *testing.T) {
 
 		cd := newCallData(mtdUnary, "123", 1, true, true, nil)
 
-		md1, err := mdp.getMetadataForCall(cd)
+		md1, err := mdp.getMetadataForCall(cd, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, md1)
 		assert.Equal(t, []string{"1"}, md1.Get("token"))
 		assert.NotSame(t, mdp.preseed, md1)
 
 		cd = newCallData(mtdUnary, "123", 2, true, true, nil)
-		md2, err := mdp.getMetadataForCall(cd)
+		md2, err := mdp.getMetadataForCall(cd, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, md2)
 		assert.Equal(t, []string{"2"}, md2.Get("token"))
@@ -365,7 +365,7 @@ func TestMetadata_getMetadataForCall(t *testing.T) {
 
 		cd := newCallData(mtdUnary, "123", 1, true, true, funcs)
 
-		md1, err := mdp.getMetadataForCall(cd)
+		md1, err := mdp.getMetadataForCall(cd, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, md1)
 		assert.Equal(t, []string{"custom-value"}, md1.Get("token"))

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -945,7 +945,7 @@ func TestRunUnary(t *testing.T) {
 
 				return []*dynamic.Message{dynamicMsg}, nil
 			}),
-			WithMetadataProvider(func(*CallData) (*metadata.MD, error) {
+			WithMetadataProvider(func(*CallData, *dynamic.Message) (*metadata.MD, error) {
 				mdv := "secret" + strconv.Itoa(callCounter)
 				return &metadata.MD{"token": []string{mdv}}, nil
 			}),


### PR DESCRIPTION
These changes were required to
- Pass current message into metadata provider function
- Rearrange makeRequest function to be able to validate input message before passing it into metadata provider function